### PR TITLE
完善版本

### DIFF
--- a/JS事件/窗口拖拽.html
+++ b/JS事件/窗口拖拽.html
@@ -23,40 +23,44 @@
                 var oEvent = ev||event;
                 x = oEvent.clientX - oDiv.offsetLeft;
                 y = oEvent.clientY - oDiv.offsetTop;
-                document.onmousemove = function(ev)         //onmousemove属性不论鼠标有没有按下都会执行
+                if(oDiv.setCapture)
                 {
-                    var oEvent = ev||event;
-                    oDiv.style.left = oEvent.clientX - x +'px';
-                    oDiv.style.top = oEvent.clientY - y+'px';
-                    if(oDiv.offsetLeft<0)
+                    oDiv.onmousemove = function(ev)         //onmousemove属性不论鼠标有没有按下都会执行
                     {
-                        oDiv.style.left=0;
-                    }
-                    else if(oDiv.offsetLeft>document.documentElement.clientWidth-oDiv.offsetWidth)
+                        var oEvent = ev||event;
+                        oDiv.style.left = oEvent.clientX - x +'px';
+                        oDiv.style.top = oEvent.clientY - y+'px';
+                    };
+                    oDiv.onmouseup = function()
                     {
-                        oDiv.style.left=document.documentElement.clientWidth-oDiv.offsetWidth +"px";
-                    }
-                    if(oDiv.offsetTop<0)
+                        oDiv.onmousemove = null;
+                        oDiv.onmouseup = null;
+                        oDiv.releaseCapture();
+                    };
+                    oDiv.setCapture();//IE6-8
+                }
+                else
+                {
+                    document.onmousemove = function(ev)         //onmousemove属性不论鼠标有没有按下都会执行
                     {
-                        oDiv.style.top=0;
-                    }
-                    else if(oDiv.offsetTop>document.documentElement.clientHeight-oDiv.offsetHeight)
+                        var oEvent = ev||event;
+                        oDiv.style.left = oEvent.clientX - x +'px';
+                        oDiv.style.top = oEvent.clientY - y+'px';
+                    };
+                    oDiv.onmouseup = function()
                     {
-                        oDiv.style.top =document.documentElement.clientHeight-oDiv.offsetHeight+'px';
-                    }
-                };
-
-                    return false;//火狐浏览器有bug，默认会拖出重影
-            };
-            oDiv.onmouseup = function()
-            {
-                document.onmousemove = null;
+                        document.onmousemove = null;
+                        document.onmouseup = null;
+                    };
+                }
+                return false;//火狐浏览器有bug，默认会拖出重影 chrome FF IE9
             };
 
         };
     </script>
 </head>
 <body>
-<div></div>
+dfjslkfjlrjsfjklr
+<div>ealkjdsldfj</div>
 </body>
 </html>


### PR DESCRIPTION
物体拖拽时会选中物体外的图片以及文字。
return false；阻止默认事件能解决chrome、FF、IE9的这类问题
若使用IE6以及以上版本可以利用事件捕获。
setCapture 将网页里所有的事件都集中到一个按钮中实现。
oBtn.setCapture();
1.不会出现鼠标移动过导致Div跟不上鼠标的运动，停止运动。（鼠标在网页中的移动转移到了选中的Div中实现）
2.不会出现选中Div之外的文字以及图片的情况。（在Div点击鼠标移动的事件都转移到了Div中实现）
